### PR TITLE
Modify Get Routines response and set up get routine by ID route

### DIFF
--- a/src/main/java/com/IronTrack/IronTrackBE/Controllers/HomeController.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Controllers/HomeController.java
@@ -1,9 +1,6 @@
 package com.IronTrack.IronTrackBE.Controllers;
 
-import com.IronTrack.IronTrackBE.Models.CreateRoutineRequest;
-import com.IronTrack.IronTrackBE.Models.CreateRoutineResponse;
-import com.IronTrack.IronTrackBE.Models.GetRoutinesResponse;
-import com.IronTrack.IronTrackBE.Models.Routine;
+import com.IronTrack.IronTrackBE.Models.*;
 import com.IronTrack.IronTrackBE.Services.HomeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/home")
+@RequestMapping("/routines")
 @RequiredArgsConstructor
 public class HomeController {
 
@@ -24,6 +21,24 @@ public class HomeController {
         List<Routine> routines = service.getRoutines();
         GetRoutinesResponse response = new GetRoutinesResponse(routines);
         return ResponseEntity.status(HttpStatus.OK.value()).body(response);
+    }
+
+    @GetMapping("/{routineId}")
+    public ResponseEntity<?> getRoutine(@PathVariable Long routineId) {
+        try {
+            Routine routine = service.getRoutine(routineId);
+            GetRoutineResponse response = new GetRoutineResponse();
+            response.setRoutine(routine);
+
+            return ResponseEntity.ok(response);
+        } catch (NullPointerException e) {
+            ErrorResponse response = new ErrorResponse();
+
+            response.setStatusCode(HttpStatus.NOT_FOUND.value());
+            response.setMessage("Routine with ID: " + routineId + " was not found");
+            return ResponseEntity.status(response.getStatusCode()).body(response);
+
+        }
     }
 
     @PostMapping("/createRoutine")

--- a/src/main/java/com/IronTrack/IronTrackBE/Controllers/HomeController.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Controllers/HomeController.java
@@ -31,13 +31,20 @@ public class HomeController {
             response.setRoutine(routine);
 
             return ResponseEntity.ok(response);
+
         } catch (NullPointerException e) {
             ErrorResponse response = new ErrorResponse();
-
             response.setStatusCode(HttpStatus.NOT_FOUND.value());
             response.setMessage("Routine with ID: " + routineId + " was not found");
+
             return ResponseEntity.status(response.getStatusCode()).body(response);
 
+        } catch (SecurityException e) {
+            ErrorResponse response = new ErrorResponse();
+            response.setStatusCode(HttpStatus.UNAUTHORIZED.value());
+            response.setMessage("Routine with ID: " + routineId + " not accessible");
+
+            return ResponseEntity.status(response.getStatusCode()).body(response);
         }
     }
 

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/Exercise.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/Exercise.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @NoArgsConstructor
 @Data
 public class Exercise {
-    private Optional<Long> id;
+    private Long id;
     public String name;
     public String type;
     public String muscle;

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/Exercise.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/Exercise.java
@@ -8,10 +8,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class Exercise {
+    private Optional<Long> id;
     public String name;
     public String type;
     public String muscle;

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/GetRoutineResponse.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/GetRoutineResponse.java
@@ -1,2 +1,15 @@
-package com.IronTrack.IronTrackBE.Models;public class GetRoutineResponse {
+package com.IronTrack.IronTrackBE.Models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetRoutineResponse {
+
+    private Routine routine;
 }

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/GetRoutineResponse.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/GetRoutineResponse.java
@@ -1,0 +1,2 @@
+package com.IronTrack.IronTrackBE.Models;public class GetRoutineResponse {
+}

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/Routine.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/Routine.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Data
 public class Routine {
     //Maybe make a list of strings
-    private Optional<Long> id;
+    private Long id;
     private String name;
     private List<RoutineExercise> exercises;
 

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/Routine.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/Routine.java
@@ -5,12 +5,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class Routine {
     //Maybe make a list of strings
+    private Optional<Long> id;
     private String name;
     private List<RoutineExercise> exercises;
 

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/RoutineExercise.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/RoutineExercise.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @AllArgsConstructor
 @NoArgsConstructor
 public class RoutineExercise {
-    private Optional<Long> id;
+    private Long id;
     private Exercise exercise;
     private String weight;
     private Integer sets;

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/RoutineExercise.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/RoutineExercise.java
@@ -5,11 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class RoutineExercise {
+    private Optional<Long> id;
     private Exercise exercise;
     private String weight;
     private Integer sets;

--- a/src/main/java/com/IronTrack/IronTrackBE/Repository/RoutineRepo.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Repository/RoutineRepo.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface RoutineRepo extends JpaRepository<RoutineEntity, Integer> {
     Optional<List<RoutineEntity>> findAllByUserEntity(UserEntity userEntity);
-
+    RoutineEntity findById(Long routineId);
 }

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
@@ -160,7 +160,7 @@ public class HomeService {
     private Exercise mapExerciseEntityToExercise(ExerciseEntity exerciseEntity) {
 
         Exercise exercise = new Exercise();
-        exercise.setId(Optional.ofNullable(exerciseEntity.getId()));
+        exercise.setId(exerciseEntity.getId());
         exercise.setDifficulty(exerciseEntity.getDifficulty());
         exercise.setEquipment(exerciseEntity.getEquipment());
         exercise.setName(exerciseEntity.getName());
@@ -174,7 +174,7 @@ public class HomeService {
     private RoutineExercise mapRoutineExerciseEntityToRoutineExercise(RoutineExercisesEntity routineExerciseEntity) {
         Exercise exercise = mapExerciseEntityToExercise(routineExerciseEntity.getExerciseEntity());
         RoutineExercise routineExercise = new RoutineExercise();
-        routineExercise.setId(Optional.ofNullable(routineExerciseEntity.getId()));
+        routineExercise.setId(routineExerciseEntity.getId());
         routineExercise.setExercise(exercise);
         routineExercise.setQuantity(routineExerciseEntity.getQuantity());
         routineExercise.setWeight(routineExerciseEntity.getWeight());

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
@@ -125,6 +125,7 @@ public class HomeService {
             }
 
             routine.setName(routineEntity.getName());
+            routine.setId(Optional.ofNullable(routineEntity.getId()));
             routine.setExercises(exercises);
             routines.add(routine);
         }
@@ -135,6 +136,7 @@ public class HomeService {
     private Exercise mapExerciseEntityToExercise(ExerciseEntity exerciseEntity) {
 
         Exercise exercise = new Exercise();
+        exercise.setId(Optional.ofNullable(exerciseEntity.getId()));
         exercise.setDifficulty(exerciseEntity.getDifficulty());
         exercise.setEquipment(exerciseEntity.getEquipment());
         exercise.setName(exerciseEntity.getName());
@@ -148,6 +150,7 @@ public class HomeService {
     private RoutineExercise mapRoutineExerciseEntityToRoutineExercise(RoutineExercisesEntity routineExerciseEntity) {
         Exercise exercise = mapExerciseEntityToExercise(routineExerciseEntity.getExerciseEntity());
         RoutineExercise routineExercise = new RoutineExercise();
+        routineExercise.setId(Optional.ofNullable(routineExerciseEntity.getId()));
         routineExercise.setExercise(exercise);
         routineExercise.setQuantity(routineExerciseEntity.getQuantity());
         routineExercise.setWeight(routineExerciseEntity.getWeight());

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
@@ -41,6 +41,28 @@ public class HomeService {
         return getUserRoutines(user);
     }
 
+    public Routine getRoutine(Long routineId) throws NullPointerException, SecurityException {
+        UserEntity user = getUserEntity();
+        RoutineEntity routineEntity = routineRepo.findById(routineId);
+        Routine routine = new Routine();
+        routine.setId(routineId);
+        try {
+            routine.setName(routineEntity.getName());
+        } catch (NullPointerException e) {
+            // catch routine being null
+            throw new NullPointerException("Routine could not be found");
+        }
+
+        if (routineEntity.getUserEntity() != user) {
+            throw new SecurityException("Routine does not belong to this user");
+        }
+
+        List<RoutineExercise> routineExercises = getRoutineExercises(routineEntity);
+        routine.setExercises(routineExercises);
+
+        return routine;
+    }
+
     public String createRoutine(CreateRoutineRequest request) throws SecurityException {
         UserEntity user = getUserEntity();
         List<ExerciseEntity> exercises = getExerciseEntities(request.getExercises());
@@ -59,6 +81,16 @@ public class HomeService {
         }
 
         throw new SecurityException("User is not authenticated");
+    }
+
+    private List<RoutineExercise> getRoutineExercises(RoutineEntity routineEntity) {
+        List<RoutineExercisesEntity> routineExercisesEntities = routineExercisesRepo.findAllByRoutineEntity(routineEntity);
+        List<RoutineExercise> routineExercises = new ArrayList<>();
+        for (RoutineExercisesEntity routineExercisesEntity: routineExercisesEntities) {
+            RoutineExercise routineExercise = mapRoutineExerciseEntityToRoutineExercise(routineExercisesEntity);
+            routineExercises.add(routineExercise);
+        }
+        return routineExercises;
     }
 
     private List<ExerciseEntity> getExerciseEntities(List<RoutineExercise> routineExercises) {
@@ -117,16 +149,8 @@ public class HomeService {
         List<RoutineEntity> routineEntities = routineRepo.findAllByUserEntity(user).orElse(new ArrayList<>());
         for (RoutineEntity routineEntity: routineEntities) {
             Routine routine = new Routine();
-            List<RoutineExercise> exercises = new ArrayList<>();
-            List<RoutineExercisesEntity> routineExerciseEntities = routineExercisesRepo.findAllByRoutineEntity(routineEntity);
-            for (RoutineExercisesEntity routineExerciseEntity : routineExerciseEntities) {
-                RoutineExercise exercise = mapRoutineExerciseEntityToRoutineExercise(routineExerciseEntity);
-                exercises.add(exercise);
-            }
-
             routine.setName(routineEntity.getName());
-            routine.setId(Optional.ofNullable(routineEntity.getId()));
-            routine.setExercises(exercises);
+            routine.setId(routineEntity.getId());
             routines.add(routine);
         }
 


### PR DESCRIPTION
The routine id's, routine exercises id's, and the exercise's id's are now sent to the client side so that back-end can reference them later when a user is editing their routine exercises.

If user makes get request to retrieve all routines, back-end responds with an array of {id, name} objects. 

If user makes get request to routines/{routineId}, back-end responds with all the data for that routine. 