### PR TITLE
Setup POST route at routines/{routine_id}

### DIFF
--- a/src/main/java/com/IronTrack/IronTrackBE/Controllers/RoutineController.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Controllers/RoutineController.java
@@ -2,14 +2,12 @@ package com.IronTrack.IronTrackBE.Controllers;
 
 import com.IronTrack.IronTrackBE.Models.GetRoutineExerciseResponse;
 import com.IronTrack.IronTrackBE.Models.RoutineExercise;
+import com.IronTrack.IronTrackBE.Models.SuccessResponse;
 import com.IronTrack.IronTrackBE.Services.RoutineService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
 
@@ -32,6 +30,35 @@ public class RoutineController {
             RoutineExercise routineExercise = service.getRoutineExercise(routineId, routineExerciseId);
             response.setRoutineExericse(routineExercise);
             return ResponseEntity.ok(response);
+        } catch (NoSuchElementException e) {
+            errorResponse.setStatusCode(HttpStatus.NOT_FOUND.value());
+            errorResponse.setMessage(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            errorResponse.setStatusCode(HttpStatus.BAD_REQUEST.value());
+            errorResponse.setMessage(e.getMessage());
+        } catch (SecurityException e) {
+            errorResponse.setStatusCode(HttpStatus.UNAUTHORIZED.value());
+            errorResponse.setMessage(e.getMessage());
+        }
+
+        return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
+
+
+    }
+
+    @PostMapping
+    public ResponseEntity<?> addRoutineExercise(
+            @PathVariable("routine_id") Long routineId,
+            @RequestBody RoutineExercise routineExercise
+    ) {
+        ErrorResponse errorResponse= new ErrorResponse();
+
+        try {
+            SuccessResponse response = new SuccessResponse();
+            service.addRoutineExercise(routineId, routineExercise);
+            response.setMessage("Successfully saved new exercise");
+            response.setStatusCode(HttpStatus.CREATED.value());
+            return ResponseEntity.status(response.getStatusCode()).body(response);
         } catch (NoSuchElementException e) {
             errorResponse.setStatusCode(HttpStatus.NOT_FOUND.value());
             errorResponse.setMessage(e.getMessage());

--- a/src/main/java/com/IronTrack/IronTrackBE/Models/SuccessResponse.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Models/SuccessResponse.java
@@ -1,0 +1,15 @@
+package com.IronTrack.IronTrackBE.Models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SuccessResponse {
+    private String message;
+    private int statusCode;
+}

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/RoutineService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/RoutineService.java
@@ -6,6 +6,7 @@ import com.IronTrack.IronTrackBE.Repository.Entities.ExerciseEntity;
 import com.IronTrack.IronTrackBE.Repository.Entities.RoutineEntity;
 import com.IronTrack.IronTrackBE.Repository.Entities.RoutineExercisesEntity;
 import com.IronTrack.IronTrackBE.Repository.Entities.UserEntity;
+import com.IronTrack.IronTrackBE.Repository.ExerciseRepo;
 import com.IronTrack.IronTrackBE.Repository.RoutineExercisesRepo;
 import com.IronTrack.IronTrackBE.Repository.RoutineRepo;
 import com.IronTrack.IronTrackBE.Repository.UserRepo;
@@ -16,6 +17,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,12 +26,27 @@ public class RoutineService {
     private final UserRepo userRepo;
     private final RoutineRepo routineRepo;
     private final RoutineExercisesRepo routineExercisesRepo;
+    private final ExerciseRepo exerciseRepo;
 
     public RoutineExercise getRoutineExercise(Long routineId, Long routineExerciseId) throws NullPointerException, SecurityException {
         RoutineEntity routine = getRoutineEntity(routineId);
         RoutineExercisesEntity routineExercises = getRoutineExercisesEntity(routine, routineExerciseId);
 
         return mapRoutineExercisesEntityToRoutineExercise(routineExercises);
+    }
+
+    public void addRoutineExercise(Long routineId, RoutineExercise routineExercise) throws NullPointerException, SecurityException {
+        RoutineEntity routine = getRoutineEntity(routineId);
+        ExerciseEntity exercise = getExerciseEntity(routineExercise);
+
+        RoutineExercisesEntity routineExercisesEntity = new RoutineExercisesEntity();
+        routineExercisesEntity.setRoutineEntity(routine);
+        routineExercisesEntity.setExerciseEntity(exercise);
+        routineExercisesEntity.setSets(routineExercise.getSets());
+        routineExercisesEntity.setQuantity(routineExercise.getQuantity());
+        routineExercisesEntity.setWeight(routineExercise.getWeight());
+        routineExercisesEntity.setQuantityUnit(routineExercise.getQuantityUnit());
+        routineExercisesRepo.save(routineExercisesEntity);
     }
 
     private UserEntity getUserEntity() {
@@ -41,6 +58,25 @@ public class RoutineService {
         }
 
         throw new SecurityException("User is not authenticated");
+    }
+
+    private ExerciseEntity getExerciseEntity(RoutineExercise routineExercise) {
+        Exercise exercise = routineExercise.getExercise();
+        Optional<ExerciseEntity> exerciseEntity = exerciseRepo.findByName(exercise.getName());
+
+        if (exerciseEntity.isPresent()) {
+            return exerciseEntity.get();
+        } else {
+            ExerciseEntity newExerciseEntity = new ExerciseEntity();
+            newExerciseEntity.setMuscle(exercise.getMuscle());
+            newExerciseEntity.setName(exercise.getName());
+            newExerciseEntity.setType(exercise.getType());
+            newExerciseEntity.setEquipment(exercise.getEquipment());
+            newExerciseEntity.setDifficulty(exercise.getDifficulty());
+            newExerciseEntity.setInstructions(exercise.getInstructions());
+            return exerciseRepo.save(newExerciseEntity);
+        }
+
     }
 
     private RoutineEntity getRoutineEntity(Long routineId) throws NoSuchElementException, SecurityException {


### PR DESCRIPTION
This route sets up the functionality when user clicks on the green "Add Exercise" button in the component below.

When users click that button, a post request is made to /api/routines/{routine_id}, which because of the proxy rewrite, routes to /{routines}/{routine_id}.

This PR sets up that POST route, which adds the newly created routine exercise to the routineExercise table.

<img width="196" alt="Screenshot 2023-10-23 at 7 20 19 PM" src="https://github.com/AkDProjects/IronTrackBE/assets/55603689/4fd3e2c2-9a35-4f5f-84f3-7686dff4cd03">
