### PR TITLE
Create RoutineExerciseHistoryEntity

### DIFF
--- a/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExerciseHistoryEntity.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExerciseHistoryEntity.java
@@ -3,8 +3,9 @@ package com.IronTrack.IronTrackBE.Repository.Entities;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.Hibernate;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
@@ -15,13 +16,13 @@ import java.util.Objects;
 @Table(name = "routine_exercises")
 
 @AllArgsConstructor
-public class RoutineExercisesEntity {
+public class RoutineExerciseHistoryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    @JoinColumn(name = "routine_id")
-    private RoutineEntity routineEntity;
+    @JoinColumn(name = "routine_exercise_id")
+    private RoutineExercisesEntity routineExerciseEntity;
     @ManyToOne
     @JoinColumn(name = "exercise_id")
     private ExerciseEntity exerciseEntity;
@@ -34,16 +35,17 @@ public class RoutineExercisesEntity {
     @Column
     private String quantityUnit;
     @Column
-    private Integer iterations;
-    @OneToMany(mappedBy = "routineExerciseHistoryEntity", cascade = CascadeType.ALL)
-    private RoutineExerciseHistoryEntity routineExerciseHistoryEntity;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime UpdatedAt;
+    @Column
+    private Integer iteration;
 
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
-        RoutineExercisesEntity that = (RoutineExercisesEntity) o;
+        RoutineExerciseHistoryEntity that = (RoutineExerciseHistoryEntity) o;
         return id != null && Objects.equals(id, that.id);
     }
 
@@ -52,3 +54,4 @@ public class RoutineExercisesEntity {
         return getClass().hashCode();
     }
 }
+

--- a/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExerciseHistoryEntity.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExerciseHistoryEntity.java
@@ -13,8 +13,7 @@ import java.util.Objects;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "routine_exercises")
-
+@Table(name = "routine_exercise_history")
 @AllArgsConstructor
 public class RoutineExerciseHistoryEntity {
     @Id

--- a/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExercisesEntity.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExercisesEntity.java
@@ -3,7 +3,6 @@ package com.IronTrack.IronTrackBE.Repository.Entities;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.Hibernate;
-import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExercisesEntity.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Repository/Entities/RoutineExercisesEntity.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.Hibernate;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
 import java.util.Objects;
 
 @Getter
@@ -35,8 +36,8 @@ public class RoutineExercisesEntity {
     private String quantityUnit;
     @Column
     private Integer iterations;
-    @OneToMany(mappedBy = "routineExerciseHistoryEntity", cascade = CascadeType.ALL)
-    private RoutineExerciseHistoryEntity routineExerciseHistoryEntity;
+    @OneToMany(mappedBy = "routineExerciseEntity", cascade = CascadeType.REMOVE)
+    private List<RoutineExerciseHistoryEntity> routineExerciseHistoryEntity;
 
 
     @Override

--- a/src/main/java/com/IronTrack/IronTrackBE/Repository/RoutineExerciseHistoryRepo.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Repository/RoutineExerciseHistoryRepo.java
@@ -1,0 +1,9 @@
+package com.IronTrack.IronTrackBE.Repository;
+
+import com.IronTrack.IronTrackBE.Repository.Entities.RoutineExerciseHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoutineExerciseHistoryRepo extends JpaRepository<RoutineExerciseHistoryEntity, Long> {
+}

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
@@ -82,6 +82,7 @@ public class HomeService {
             RoutineExercise routineExercise = mapRoutineExerciseEntityToRoutineExercise(routineExercisesEntity);
             routineExercises.add(routineExercise);
         }
+
         return routineExercises;
     }
 

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
@@ -136,7 +136,7 @@ public class HomeService {
             routineExercisesEntity.setQuantityUnit(routineExercise.getQuantityUnit());
             routineExercisesEntity.setIterations(0);
 
-            savedRoutineExercises.add(routineExercisesRepo.save(routineExercisesEntity));;
+            savedRoutineExercises.add(routineExercisesRepo.save(routineExercisesEntity));
         }
 
         return savedRoutineExercises;

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/HomeService.java
@@ -1,19 +1,9 @@
 package com.IronTrack.IronTrackBE.Services;
 
 import com.IronTrack.IronTrackBE.Models.*;
-import com.IronTrack.IronTrackBE.Repository.Entities.ExerciseEntity;
-import com.IronTrack.IronTrackBE.Repository.Entities.RoutineEntity;
-import com.IronTrack.IronTrackBE.Repository.Entities.RoutineExercisesEntity;
-import com.IronTrack.IronTrackBE.Repository.Entities.UserEntity;
-import com.IronTrack.IronTrackBE.Repository.ExerciseRepo;
-import com.IronTrack.IronTrackBE.Repository.RoutineExercisesRepo;
-import com.IronTrack.IronTrackBE.Repository.RoutineRepo;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.IronTrack.IronTrackBE.Repository.Entities.*;
+import com.IronTrack.IronTrackBE.Repository.*;
 
-import java.net.http.HttpResponse;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,6 +11,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import com.IronTrack.IronTrackBE.Repository.UserRepo;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -33,7 +24,7 @@ public class HomeService {
     private final RoutineRepo routineRepo;
     private final ExerciseRepo exerciseRepo;
     private final RoutineExercisesRepo routineExercisesRepo;
-    private final ApiNinjasService apiNinjas;
+    private final RoutineExerciseHistoryRepo routineExerciseHistoryRepo;
 
     public List<Routine> getRoutines() {
         UserEntity user = getUserEntity();
@@ -67,7 +58,8 @@ public class HomeService {
         UserEntity user = getUserEntity();
         List<ExerciseEntity> exercises = getExerciseEntities(request.getExercises());
         RoutineEntity routine = saveRoutine(request.getName(), user);
-        saveRoutineExerciseEntities(request.getExercises(), routine, exercises);
+        List<RoutineExercisesEntity> routineExercises = saveRoutineExerciseEntities(request.getExercises(), routine, exercises);
+        saveRoutineExerciseHistoryEntities(routineExercises);
 
         return "Successfully created new routine";
     }
@@ -127,7 +119,9 @@ public class HomeService {
         return routineRepo.save(routineEntity);
     }
 
-    private void saveRoutineExerciseEntities(List<RoutineExercise> routineExercises, RoutineEntity routine, List<ExerciseEntity> exercises) {
+    private List<RoutineExercisesEntity> saveRoutineExerciseEntities(List<RoutineExercise> routineExercises, RoutineEntity routine, List<ExerciseEntity> exercises) {
+        List<RoutineExercisesEntity> savedRoutineExercises = new ArrayList<>();
+
         for (int i = 0; i < routineExercises.size(); i++) {
             RoutineExercise routineExercise = routineExercises.get(i);
             ExerciseEntity exercise = exercises.get(i);
@@ -139,8 +133,28 @@ public class HomeService {
             routineExercisesEntity.setSets(routineExercise.getSets());
             routineExercisesEntity.setQuantity(routineExercise.getQuantity());
             routineExercisesEntity.setQuantityUnit(routineExercise.getQuantityUnit());
+            routineExercisesEntity.setIterations(0);
 
-            routineExercisesRepo.save(routineExercisesEntity);
+            savedRoutineExercises.add(routineExercisesRepo.save(routineExercisesEntity));;
+        }
+
+        return savedRoutineExercises;
+    }
+
+    private void saveRoutineExerciseHistoryEntities(List<RoutineExercisesEntity> routineExerciseEntities) {
+        for (RoutineExercisesEntity routineExerciseEntity : routineExerciseEntities) {
+
+            RoutineExerciseHistoryEntity routineExerciseHistoryEntity = new RoutineExerciseHistoryEntity();
+            routineExerciseHistoryEntity.setExerciseEntity(routineExerciseEntity.getExerciseEntity());
+            routineExerciseHistoryEntity.setRoutineExerciseEntity(routineExerciseEntity);
+            routineExerciseHistoryEntity.setWeight(routineExerciseEntity.getWeight());
+            routineExerciseHistoryEntity.setSets(routineExerciseEntity.getSets());
+            routineExerciseHistoryEntity.setQuantity(routineExerciseEntity.getQuantity());
+            routineExerciseHistoryEntity.setQuantityUnit(routineExerciseEntity.getQuantityUnit());
+            routineExerciseHistoryEntity.setIteration(routineExerciseEntity.getIterations());
+            routineExerciseHistoryEntity.setUpdatedAt(LocalDateTime.now());
+
+            routineExerciseHistoryRepo.save(routineExerciseHistoryEntity);
         }
     }
 

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/RoutineService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/RoutineService.java
@@ -68,7 +68,7 @@ public class RoutineService {
         routineExerciseHistoryRepo.save(routineExerciseHistoryEntity);
     }
 
-    public void updateRoutineExercise(Long routineId, Long routineExerciseId, RoutineExercise routineExercise) throws NullPointerException, SecurityException, Exception {
+    public void updateRoutineExercise(Long routineId, Long routineExerciseId, RoutineExercise routineExercise) throws Exception {
         RoutineEntity routine = getRoutineEntity(routineId);
         RoutineExercisesEntity newRoutineExercise = getRoutineExercisesEntity(routine, routineExerciseId);
         ExerciseEntity exerciseEntity = getExerciseEntity(routineExercise);

--- a/src/main/java/com/IronTrack/IronTrackBE/Services/RoutineService.java
+++ b/src/main/java/com/IronTrack/IronTrackBE/Services/RoutineService.java
@@ -2,20 +2,15 @@ package com.IronTrack.IronTrackBE.Services;
 
 import com.IronTrack.IronTrackBE.Models.Exercise;
 import com.IronTrack.IronTrackBE.Models.RoutineExercise;
-import com.IronTrack.IronTrackBE.Repository.Entities.ExerciseEntity;
-import com.IronTrack.IronTrackBE.Repository.Entities.RoutineEntity;
-import com.IronTrack.IronTrackBE.Repository.Entities.RoutineExercisesEntity;
-import com.IronTrack.IronTrackBE.Repository.Entities.UserEntity;
-import com.IronTrack.IronTrackBE.Repository.ExerciseRepo;
-import com.IronTrack.IronTrackBE.Repository.RoutineExercisesRepo;
-import com.IronTrack.IronTrackBE.Repository.RoutineRepo;
-import com.IronTrack.IronTrackBE.Repository.UserRepo;
+import com.IronTrack.IronTrackBE.Repository.*;
+import com.IronTrack.IronTrackBE.Repository.Entities.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -27,6 +22,7 @@ public class RoutineService {
     private final RoutineRepo routineRepo;
     private final RoutineExercisesRepo routineExercisesRepo;
     private final ExerciseRepo exerciseRepo;
+    private final RoutineExerciseHistoryRepo routineExerciseHistoryRepo;
 
     public RoutineExercise getRoutineExercise(Long routineId, Long routineExerciseId) throws NullPointerException, SecurityException {
         RoutineEntity routine = getRoutineEntity(routineId);
@@ -52,7 +48,24 @@ public class RoutineService {
         routineExercisesEntity.setQuantity(routineExercise.getQuantity());
         routineExercisesEntity.setWeight(routineExercise.getWeight());
         routineExercisesEntity.setQuantityUnit(routineExercise.getQuantityUnit());
-        routineExercisesRepo.save(routineExercisesEntity);
+        routineExercisesEntity.setIterations(0);
+        RoutineExercisesEntity result = routineExercisesRepo.save(routineExercisesEntity);
+
+        addRoutineExerciseHistory(result);
+    }
+
+    public void addRoutineExerciseHistory(RoutineExercisesEntity routineExerciseEntity) {
+        RoutineExerciseHistoryEntity routineExerciseHistoryEntity = new RoutineExerciseHistoryEntity();
+        routineExerciseHistoryEntity.setExerciseEntity(routineExerciseEntity.getExerciseEntity());
+        routineExerciseHistoryEntity.setRoutineExerciseEntity(routineExerciseEntity);
+        routineExerciseHistoryEntity.setWeight(routineExerciseEntity.getWeight());
+        routineExerciseHistoryEntity.setSets(routineExerciseEntity.getSets());
+        routineExerciseHistoryEntity.setQuantity(routineExerciseEntity.getQuantity());
+        routineExerciseHistoryEntity.setQuantityUnit(routineExerciseEntity.getQuantityUnit());
+        routineExerciseHistoryEntity.setIteration(routineExerciseEntity.getIterations());
+        routineExerciseHistoryEntity.setUpdatedAt(LocalDateTime.now());
+
+        routineExerciseHistoryRepo.save(routineExerciseHistoryEntity);
     }
 
     public void updateRoutineExercise(Long routineId, Long routineExerciseId, RoutineExercise routineExercise) throws NullPointerException, SecurityException, Exception {
@@ -65,7 +78,10 @@ public class RoutineService {
             newRoutineExercise.setQuantity(routineExercise.getQuantity());
             newRoutineExercise.setSets(routineExercise.getSets());
             newRoutineExercise.setWeight(routineExercise.getWeight());
-            routineExercisesRepo.save(newRoutineExercise);
+            newRoutineExercise.setIterations(newRoutineExercise.getIterations() + 1);
+            RoutineExercisesEntity result = routineExercisesRepo.save(newRoutineExercise);
+            addRoutineExerciseHistory(result);
+
         } catch (Exception ex) {
             throw new Exception("There was a problem updating the routine exercise");
         }


### PR DESCRIPTION
Link to Trello Ticket: [Create Routine Exercise History Table](https://trello.com/c/arWHgrIc/46-create-routine-exercise-history-table)

- A routine Exercise History table exists in the DB
- Everytime a routine Exercise gets modified or created, a routine exercise history entry is made that stores the relevant information of that routine exercise
- Routine Exercise table has an ‘iterations’ column which helps traingulate the correct routineExerciseHistory entity.